### PR TITLE
Prevent map touch events from propagating to the web page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -989,7 +989,8 @@ export default class Map extends Component {
       position: 'relative',
       display: 'inline-block',
       overflow: 'hidden',
-      background: '#dddddd'
+      background: '#dddddd',
+      touchAction: "none"
     }
 
     return (


### PR DESCRIPTION
Adding `touch-action: none` CSS property prevents touch events
originating from the map component, such as dragging and
pinch-zooming, from propagating to the web page.

fixes #2