### PR TITLE
allow map to be used on page that scrolls

### DIFF
--- a/src/utils/parent-position.js
+++ b/src/utils/parent-position.js
@@ -1,6 +1,6 @@
 export default function parentPosition (element) {
-  var x = 0
-  var y = 0
+  var x = -window.scrollX
+  var y = -window.scrollY
   var first = true
 
   while (element) {


### PR DESCRIPTION
if the scroll position is not taken into consideration then if the page is scrolled the map will bug.

open the demo https://mariusandra.github.io/pigeon-maps/
make the window height small
leave the map on the top of the screen
try to move it
(like this https://imgur.com/a/qtDdz1K)