### PR TITLE
Explicitly set touch event listeners to use non-passive mode.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -184,7 +184,7 @@ export default class Map extends Component {
     }
   }
 
-  wa = (e, t) => window.addEventListener(e, t)
+  wa = (e, t, o) => window.addEventListener(e, t, o)
   wr = (e, t) => window.removeEventListener(e, t)
 
   bindMouseEvents = () => {
@@ -194,9 +194,9 @@ export default class Map extends Component {
   }
 
   bindTouchEvents = () => {
-    this.wa('touchstart', this.handleTouchStart)
-    this.wa('touchmove', this.handleTouchMove)
-    this.wa('touchend', this.handleTouchEnd)
+    this.wa('touchstart', this.handleTouchStart, { passive: false })
+    this.wa('touchmove', this.handleTouchMove, { passive: false })
+    this.wa('touchend', this.handleTouchEnd, { passive: false })
   }
 
   unbindMouseEvents = () => {


### PR DESCRIPTION
As of iOS 11.3 touch event listeners in Safari use passive mode by default (it's documented in [Safari 11 release notes](https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_11_1.html)) which breaks interaction with map on iOS. You can test this by going on iOS Safari to https://pigeon-maps.js.org and trying to move or zoom map. Whole page is scrolled or zoomed simultaneously with map which make it almost impossible to use.
In this Pull Request `{ passive: false }` object is passed as third argument to `window.addEventListener()` to explicitly set touch event listeners to use non-passive mode.