### PR TITLE
fix bug zoom position when browser loss focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ If you're interested in making a new plugin, check out the code of [pigeon-marke
 
 **warningZIndex** - The `z-index` value for the meta warning. Defaults to `100`
 
+**boxClassname** - The classname for the tiles div, allowing you to style it with a filter css property without impacting the overlays.
+
 ### Overlays
 
 `<Map />` takes random React components as its children. The children may have these special props:

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -159,7 +159,8 @@ export default class App extends Component {
                     ? <WikimediaAttribution />
                     : null}
             defaultWidth={600}
-            height={400}>
+            height={400}
+            boxClassname="pigeon-filters">
             {Object.keys(markers).map(key => (
               <Marker key={key} anchor={markers[key][0]} payload={key} onClick={this.handleMarkerClick} />
             ))}

--- a/demo/index.html
+++ b/demo/index.html
@@ -33,5 +33,9 @@
       background-position: 0 0;
       background-size: 65px 20px;
     }
+
+    .pigeon-filters {
+      filter: saturate(20%);
+    }
   </style>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -766,14 +766,14 @@ export default class Map extends Component {
 
       if (!zoomSnap && this._zoomTarget) {
         const stillToAdd = this._zoomTarget - this.state.zoom
-        this.zoomAroundMouse(addToZoom + stillToAdd, zoomSnap)
+        this.zoomAroundMouse(addToZoom + stillToAdd, zoomSnap, event)
       } else {
         if (animate) {
-          this.zoomAroundMouse(addToZoom, zoomSnap)
+          this.zoomAroundMouse(addToZoom, zoomSnap, event)
         } else {
           if (!this._lastWheel || performanceNow() - this._lastWheel > ANIMATION_TIME) {
             this._lastWheel = performanceNow()
-            this.zoomAroundMouse(addToZoom, zoomSnap)
+            this.zoomAroundMouse(addToZoom, zoomSnap, event)
           }
         }
       }
@@ -799,9 +799,11 @@ export default class Map extends Component {
     }
   }
 
-  zoomAroundMouse = (zoomDiff, zoomSnap = false) => {
+  zoomAroundMouse = (zoomDiff, zoomSnap = false, event) => {
     const { zoom } = this.state
     const { minZoom, maxZoom } = this.props
+
+    this._mousePosition = getMousePixel(this._containerRef, event)
 
     if (!this._mousePosition || (zoom === minZoom && zoomDiff < 0) || (zoom === maxZoom && zoomDiff > 0)) {
       return

--- a/src/index.js
+++ b/src/index.js
@@ -999,6 +999,7 @@ export default class Map extends Component {
       transform: `scale(${scale}, ${scale})`,
       transformOrigin: 'top left'
     }
+    const boxClassname = this.props.boxClassname || ""
 
     const left = -((tileCenterX - tileMinX) * 256 - scaleWidth / 2)
     const top = -((tileCenterY - tileMinY) * 256 - scaleHeight / 2)
@@ -1012,7 +1013,7 @@ export default class Map extends Component {
     }
 
     return (
-      <div style={boxStyle}>
+      <div style={boxStyle} className={boxClassname}>
         <div style={tilesStyle}>
           {tiles.map(tile => (
             <img


### PR DESCRIPTION
Zoom position is wrong when the navigator loss the focus.

When we zoom without giving focus to the navigator, the mouse position was not changed.

