### PR TITLE
Fix "0 0 0 0" appearing with no size container

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1210,13 +1210,15 @@ export default class Map extends Component {
       background: '#dddddd',
       touchAction: touchEvents ? (twoFingerDrag ? 'pan-x pan-y' : 'none') : 'auto'
     }
-
+    
+    const hasSize = !!(width && height);
+    
     return (
       <div style={containerStyle} ref={this.setRef} onWheel={this.handleWheel}>
-        {width && height && this.renderTiles()}
-        {width && height && this.renderOverlays()}
-        {width && height && this.renderAttribution()}
-        {width && height && this.renderWarning()}
+        {hasSize && this.renderTiles()}
+        {hasSize && this.renderOverlays()}
+        {hasSize && this.renderAttribution()}
+        {hasSize && this.renderWarning()}
       </div>
     )
   }


### PR DESCRIPTION
When a container has no size, `width` or `height` equals to `0`. React ignore false values, but print 0's. I stumbled upon this issue when my map was in a flexbox with no specified size at loading time, and it was showing "0 0 0 0" instead of the map (or nothing)