### PR TITLE
Reduce size

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,15 +1,16 @@
 {
   "env": {
     "inferno": {
-      "presets": ["es2015", "stage-0"],
+      "presets": [["es2015", {"modules": false}], "stage-0"],
       "plugins": [
         "inferno",
         "transform-babel-env-inline"
       ]
     },
     "react": {
-      "presets": ["es2015", "stage-0", "react"],
+      "presets": [["es2015", {"modules": false}], "stage-0", "react"],
       "plugins": [
+        ["transform-react-remove-prop-types", { "mode": "unsafe-wrap" }],
         "transform-babel-env-inline"
       ],
     }

--- a/.babelrc
+++ b/.babelrc
@@ -1,14 +1,14 @@
 {
   "env": {
     "inferno": {
-      "presets": [["es2015", {"modules": false}], "stage-0"],
+      "presets": [["es2015", {"modules": false, "loose": true}], "stage-0"],
       "plugins": [
         "inferno",
         "transform-babel-env-inline"
       ]
     },
     "react": {
-      "presets": [["es2015", {"modules": false}], "stage-0", "react"],
+      "presets": [["es2015", {"modules": false, "loose": true}], "stage-0", "react"],
       "plugins": [
         ["transform-react-remove-prop-types", { "mode": "unsafe-wrap" }],
         "transform-babel-env-inline"

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "build:demo:react": "BABEL_ENV=react node build.js production",
     "build:demo:inferno": "BABEL_ENV=inferno node build.js production",
     "build:lib": "npm run build:lib:react && npm run build:lib:inferno",
-    "build:lib:inferno": "BABEL_ENV=inferno ./node_modules/.bin/babel src --out-dir lib/inferno && ./node_modules/.bin/babel --no-babelrc --plugins minify-dead-code-elimination lib/inferno --out-dir lib/inferno",
-    "build:lib:react": "BABEL_ENV=react ./node_modules/.bin/babel src --out-dir lib/react && ./node_modules/.bin/babel --no-babelrc --plugins minify-dead-code-elimination lib/react --out-dir lib/react",
+    "build:lib:inferno": "BABEL_ENV=inferno rollup -c",
+    "build:lib:react": "BABEL_ENV=react rollup -c",
     "prepublish": "npm run build:lib",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -54,6 +54,7 @@
     "babel-plugin-minify-dead-code-elimination": "^0.2.0",
     "babel-plugin-react-transform": "^3.0.0",
     "babel-plugin-transform-babel-env-inline": "^0.0.1",
+    "babel-plugin-transform-react-remove-prop-types": "0.4.19",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
@@ -69,6 +70,8 @@
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
+    "rollup": "^1.6.0",
+    "rollup-plugin-babel": "3",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.1"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,17 @@
+import babel from 'rollup-plugin-babel'
+
+const libName = process.env.BABEL_ENV
+
+export default [
+  {
+    input: './src/infact.js',
+    output: { file: `lib/${libName}/infact.js`, format: 'cjs' },
+    plugins: [babel()]
+  },
+  {
+    input: './src/index.js',
+    output: { file: `lib/${libName}/index.js`, format: 'cjs' },
+    external: ['prop-types', './infact'],
+    plugins: [babel()]
+  }
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/node@^11.9.5":
+  version "11.10.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.10.5.tgz#fbaca34086bdc118011e1f05c47688d432f2d571"
+  integrity sha512-DuIRlQbX4K+d5I+GMnv+UfnGh+ist0RdlvOp+JZ7ePJ6KQONCFQv/gKYSU1ZzbVdFSUCKZOltjmpFAGGv5MdYA==
+
 abbrev@1:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
@@ -36,6 +46,11 @@ acorn@^4.0.3:
 acorn@^5.0.0, acorn@^5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.2.tgz#911cb53e036807cf0fa778dc5d370fbd864246d7"
+
+acorn@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
+  integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
 ajv-keywords@^2.0.0, ajv-keywords@^2.1.0:
   version "2.1.0"
@@ -838,6 +853,11 @@ babel-plugin-transform-react-jsx@^6.24.1:
     babel-helper-builder-react-jsx "^6.24.1"
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-remove-prop-types@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.19.tgz#dc9d8fb176a407a75efe73f231550450e29a3b17"
+  integrity sha512-f49NsaohQ1ByY20nUrpc30QFdbeT4ntV4PAL2vSZe6uCB5nqAcqXS/qzU+aI6ZfYhWASx5eIsTFvFrs1B2ffGg==
 
 babel-plugin-transform-regenerator@^6.24.1:
   version "6.26.0"
@@ -1918,6 +1938,11 @@ estraverse@^4.0.0, estraverse@^4.1.1, estraverse@^4.2.0:
 estraverse@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
+
+estree-walker@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
+  integrity sha1-va/oCVOD2EFNXcLs9MkXO225QS4=
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -3794,6 +3819,30 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^2.0.0"
     inherits "^2.0.1"
+
+rollup-plugin-babel@3:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-3.0.7.tgz#5b13611f1ab8922497e9d15197ae5d8a23fe3b1e"
+  integrity sha512-bVe2y0z/V5Ax1qU8NX/0idmzIwJPdUGu8Xx3vXH73h0yGjxfv2gkFI82MBVg49SlsFlLTBadBHb67zy4TWM3hA==
+  dependencies:
+    rollup-pluginutils "^1.5.0"
+
+rollup-pluginutils@^1.5.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
+  integrity sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=
+  dependencies:
+    estree-walker "^0.2.1"
+    minimatch "^3.0.2"
+
+rollup@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.6.0.tgz#4329f4634718197c678d18491724d50d8b7ee76c"
+  integrity sha512-qu9iWyuiOxAuBM8cAwLuqPclYdarIpayrkfQB7aTGTiyYPbvx+qVF33sIznfq4bxZCiytQux/FvZieUBAXivCw==
+  dependencies:
+    "@types/estree" "0.0.39"
+    "@types/node" "^11.9.5"
+    acorn "^6.1.1"
 
 run-async@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
Hey, I'm a big fan of the library.

Since reducing bundle-size is an important focus for this library, I went in and did some more optimizations. What I did boils down to this:
* Use Rollup instead of only babel for building the library. This is where the majority of the size savings come from.
* Remove prop-types when in production mode using [this plugin](https://www.npmjs.com/package/babel-plugin-transform-react-remove-prop-types). This lets the library user get the benefits of the prop-type warnings when they're in development mode, but removes them from the final bundle in production.
* Use babels "loose" setting which creates smaller, but not quite as spec-compliant output. (In my experience very safe to use)

I used an example project to measure the savings with webpack-bundle-analyzer. The measured savings were as follows:
* Minified: 22.85kb -> 20.16kb
* Minified + Gzipped: 7.13kb -> 6.44kb

So basically 10% reduction. Looking forward to any questions or feedback.