### PR TITLE
Fix issue #82 - Can't zoom with scrollwheel

### DIFF
--- a/src/map.tsx
+++ b/src/map.tsx
@@ -286,9 +286,9 @@ export class Map extends Component<MapProps, MapState> {
         requestAnimationFrame(this.updateWidthHeight)
       }
       this.bindResizeEvent()
-      this.bindWheelEvent()
     }
 
+    this.bindWheelEvent()
     this.syncToProps()
   }
 
@@ -296,9 +296,10 @@ export class Map extends Component<MapProps, MapState> {
     this.props.mouseEvents && this.unbindMouseEvents()
     this.props.touchEvents && this.unbindTouchEvents()
 
+    this.unbindWheelEvent()
+
     if (!this.props.width || !this.props.height) {
       this.unbindResizeEvent()
-      this.unbindWheelEvent()
     }
   }
 


### PR DESCRIPTION
Fixes the bug that prevented to use mousewheel to scroll when both `width` and `height` properties were set.

Fix #82