### PR TITLE
Use a ResizeObserver to update the size even when the window doesn't resize

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "rollup-plugin-dts": "^1.4.10",
     "rollup-plugin-typescript2": "^0.27.2",
     "tslib": "^2.0.1",
-    "typescript": "^3.9.7",
+    "typescript": "^4.2.3",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0"

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -250,6 +250,8 @@ export class Map extends Component<MapProps, MapState> {
   _lastCenter: Point
   _centerStart?: Point
 
+  _resizeObserver = null
+
   constructor(props: MapProps) {
     super(props)
 
@@ -288,6 +290,14 @@ export class Map extends Component<MapProps, MapState> {
 
     this.bindWheelEvent()
     this.syncToProps()
+
+    if (typeof ResizeObserver != 'undefined') {
+      this._resizeObserver = new ResizeObserver(() => {
+        this.updateWidthHeight()
+      })
+
+      this._resizeObserver.observe(this._containerRef)
+    }
   }
 
   componentWillUnmount(): void {
@@ -298,6 +308,10 @@ export class Map extends Component<MapProps, MapState> {
 
     if (!this.props.width || !this.props.height) {
       this.unbindResizeEvent()
+    }
+
+    if (this._resizeObserver) {
+      this._resizeObserver.disconnect()
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1976,9 +1976,9 @@ camelcase@^5.0.0:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001111:
-  version "1.0.30001112"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001112.tgz#0fffc3b934ff56ff0548c37bc9dad7d882bcf672"
-  integrity sha512-J05RTQlqsatidif/38aN3PGULCLrg8OYQOlJUKbeYVzC2mGZkZLIztwRlB3MtrfLmawUmjFlNJvy/uhwniIe1Q==
+  version "1.0.30001198"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001198.tgz#ed2d9b5f060322ba2efa42afdc56dee3255473f4"
+  integrity sha512-r5GGgESqOPZzwvdLVER374FpQu2WluCF1Z2DSiFJ89KSmGjT0LVKjgv4NcAqHmGWF9ihNpqRI9KXO9Ex4sKsgA==
 
 chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"
@@ -6300,10 +6300,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.7:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
There are cases where the map size changes but the window size stays the same (so the `resize` event doesn't trigger), causing these grey areas:

https://user-images.githubusercontent.com/4586894/110855451-a7742e80-82b6-11eb-90d0-05cc5895fff1.mp4

A ResizeObserver can be used to still update the measured size:

https://user-images.githubusercontent.com/4586894/110855460-a93df200-82b6-11eb-9d80-559c75454573.mp4

(I wasn't able to achieve this in "userland" via the exposed props)