### PR TITLE
Providers: Set default DPR to 1

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -3,14 +3,14 @@ export function osm(x: number, y: number, z: number): string {
   return `https://${s}.tile.openstreetmap.org/${z}/${x}/${y}.png`
 }
 
-export function stamenToner(x: number, y: number, z: number, dpr: number): string {
+export function stamenToner(x: number, y: number, z: number, dpr = 1): string {
   return `https://stamen-tiles.a.ssl.fastly.net/toner/${z}/${x}/${y}${dpr >= 2 ? '@2x' : ''}.png`
 }
 
-export function stamenTerrain(x: number, y: number, z: number, dpr: number): string {
+export function stamenTerrain(x: number, y: number, z: number, dpr = 1): string {
   return `https://stamen-tiles.a.ssl.fastly.net/terrain/${z}/${x}/${y}${dpr >= 2 ? '@2x' : ''}.jpg`
 }
 
-export const maptiler = (apiKey: string, map = 'streets') => (x: number, y: number, z: number, dpr: number): string => {
+export const maptiler = (apiKey: string, map = 'streets') => (x: number, y: number, z: number, dpr = 1): string => {
   return `https://api.maptiler.com/maps/${map}/256/${z}/${x}/${y}${dpr >= 2 ? '@2x' : ''}.png?key=${apiKey}`
 }


### PR DESCRIPTION
type of `MapProps.provider` does not match type of provider functions exported from src/providers.ts.

This means that if using typescript and passing a provider to props of map, you need to add ts-ignore / ts-expect-error to not get an error.

This PR fixes that issue, setting the default dpr to 1.