### PR TITLE
small feature: generalize the DOM element for tiles beyond just image elements

### DIFF
--- a/src/map/Map.tsx
+++ b/src/map/Map.tsx
@@ -94,6 +94,29 @@ function srcSet(
   return dprs.map((dpr) => url(x, y, z, dpr) + (dpr === 1 ? '' : ` ${dpr}x`)).join(', ')
 }
 
+const ImgTile = props => {
+  let tile = props.tile
+  return <img
+    src={tile.url}
+    srcSet={tile.srcSet}
+    width={tile.width}
+    height={tile.height}
+    loading={'lazy'}
+    onLoad={() => props.imageLoaded(tile.key)}
+    alt={''}
+    style={{
+      position: 'absolute',
+      left: tile.left,
+      top: tile.top,
+      willChange: 'transform',
+      // TODO: check this
+      // transform: tile.transform,
+      transformOrigin: 'top left',
+      opacity: 1,
+    }}
+  />
+}
+
 export class Map extends Component<MapProps, MapReactState> {
   static defaultProps = {
     animate: true,
@@ -110,6 +133,7 @@ export class Map extends Component<MapProps, MapReactState> {
     maxZoom: 18,
     limitBounds: 'center',
     dprs: [],
+    tile: ImgTile
   }
 
   _containerRef?: HTMLDivElement
@@ -1202,30 +1226,13 @@ export class Map extends Component<MapProps, MapReactState> {
       transform: `translate(${left}px, ${top}px)`,
     }
 
+    const Tile = this.props.tile
+
     return (
       <div style={boxStyle} className={boxClassname}>
         <div className="pigeon-tiles" style={tilesStyle}>
           {tiles.map((tile) => (
-            <img
-              key={tile.key}
-              src={tile.url}
-              srcSet={tile.srcSet}
-              width={tile.width}
-              height={tile.height}
-              loading={'lazy'}
-              onLoad={() => this.imageLoaded(tile.key)}
-              alt={''}
-              style={{
-                position: 'absolute',
-                left: tile.left,
-                top: tile.top,
-                willChange: 'transform',
-                // TODO: check this
-                // transform: tile.transform,
-                transformOrigin: 'top left',
-                opacity: 1,
-              }}
-            />
+            <Tile key={tile.key} tile={tile} imageLoaded={this.imageLoaded}/>
           ))}
         </div>
       </div>


### PR DESCRIPTION
this adds a new parameter/prop to Map for passing in a component class for the tiles; it defaults to the existing `img` elements. This is useful if you want to tile other DOM elements like `div`, `svg` or `canvas`.

This is implemented as a small refactoring and may not be complete; it would be better to move `Img`-specific attributes such as srcSet into ImgTile instead of being generic to all Tiles. But I'd like to gauge interest in pursing this idea. Thanks for this library!