### PR TITLE
Attach sub elements

### DIFF
--- a/demo/Demo.tsx
+++ b/demo/Demo.tsx
@@ -17,6 +17,11 @@ const lat2tile = (lat, zoom) =>
   ((1 - Math.log(Math.tan((lat * Math.PI) / 180) + 1 / Math.cos((lat * Math.PI) / 180)) / Math.PI) / 2) *
   Math.pow(2, zoom)
 
+
+const WrapperComponent = ({children, attachOverlayChild}) => (
+    React.Children.map(children, (child) => attachOverlayChild(child))
+);
+
 const Banner = () => (
   <a href="https://github.com/mariusandra/pigeon-maps">
     <img
@@ -148,15 +153,17 @@ export function Demo(): JSX.Element {
           defaultWidth={600}
           height={400}
         >
-          {Object.keys(markers).map((key, index) => (
-            <Marker
-              key={key}
-              anchor={markers[key][0]}
-              payload={key}
-              onClick={handleMarkerClick}
-              width={29 + 10 * index}
-            />
-          ))}
+          <WrapperComponent>
+              {Object.keys(markers).map((key, index) => (
+                <Marker
+                  key={key}
+                  anchor={markers[key][0]}
+                  payload={key}
+                  onClick={handleMarkerClick}
+                  width={29 + 10 * index}
+                />
+              ))}
+          </WrapperComponent>
           <Draggable
             anchor={state.dragAnchor}
             onDragEnd={(dragAnchor) => setState({ dragAnchor })}

--- a/src/map/Map.tsx
+++ b/src/map/Map.tsx
@@ -1239,7 +1239,7 @@ export class Map extends Component<MapProps, MapReactState> {
     )
   }
 
-  attachOverlayChild = (child: any, mapState?: MapState): any => {
+  attachOverlayChild = (child: React.ReactNode, mapState?: MapState): React.ReactNode => {
       if (!child) {
         return null
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,13 +131,11 @@ export interface MapState {
   center: Point
   width: number
   height: number
-  isFullscreen: boolean
 }
 
 export interface PigeonProps {
   anchor?: Point
   offset?: Point
-  position?: Point
   left?: number
   top?: number
   mapState?: MapState

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,11 +131,13 @@ export interface MapState {
   center: Point
   width: number
   height: number
+  isFullscreen: boolean
 }
 
 export interface PigeonProps {
   anchor?: Point
   offset?: Point
+  position?: Point
   left?: number
   top?: number
   mapState?: MapState
@@ -145,4 +147,5 @@ export interface PigeonProps {
   latLngToPixel?: (latLng: Point, center?: Point, zoom?: number) => Point
   pixelToLatLng?: (pixel: Point, center?: Point, zoom?: number) => Point
   setCenterZoom?: (center: Point | null, zoom: number, zoomAround?: Point | null, animationDuration?: number) => void
+  attachOverlayChild?: (child: any, mapState?: MapState) => any
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,5 +145,5 @@ export interface PigeonProps {
   latLngToPixel?: (latLng: Point, center?: Point, zoom?: number) => Point
   pixelToLatLng?: (pixel: Point, center?: Point, zoom?: number) => Point
   setCenterZoom?: (center: Point | null, zoom: number, zoomAround?: Point | null, animationDuration?: number) => void
-  attachOverlayChild?: (child: any, mapState?: MapState) => any
+  attachOverlayChild?: (child: React.ReactNode, mapState?: MapState) => React.ReactNode
 }


### PR DESCRIPTION
Right now it's not that easy to wrap components around each other and still attach them to the map like all the other components will (hopefully I'm not missing something).

This pr makes the cloning part of the `renderOverlay` method accessible via a prop (I call that cloning part attaching to the map).
This would enable all components that are attached to the map already to attach other components as well cleanly.

If this pr is accepted I would create another one where the `PigeonProps` are stored in a context. Thus a component could attach itself as a child component even inside of fragments or whatever without the intervention of the parent.