### PR TITLE
fix: prevent rtl pages from breaking map display 

### DIFF
--- a/src/map/Map.tsx
+++ b/src/map/Map.tsx
@@ -1400,7 +1400,7 @@ export class Map extends Component<MapProps, MapReactState> {
     const hasSize = !!(width && height)
 
     return (
-      <div style={containerStyle} ref={this.setRef}>
+      <div style={containerStyle} ref={this.setRef} dir="ltr">
         {hasSize && this.renderTiles()}
         {hasSize && this.renderOverlays()}
         {hasSize && this.renderAttribution()}


### PR DESCRIPTION
Setting `dir="ltr"` explicitly on it's own container tag, causes map elements to always load left to right, and prevents the map display breaking in RTL environments.

Fixed #144 