### PR TITLE
fix pointer events for custom marker and custom map cursors

### DIFF
--- a/src/map/Map.tsx
+++ b/src/map/Map.tsx
@@ -1352,7 +1352,6 @@ export class Map extends Component<MapProps, MapReactState> {
         width: width,
         height: height,
         overflow: 'hidden',
-        pointerEvents: 'none',
         opacity: showWarning ? 100 : 0,
         transition: 'opacity 300ms',
         background: 'rgba(0,0,0,0.5)',

--- a/src/overlays/Marker.tsx
+++ b/src/overlays/Marker.tsx
@@ -52,7 +52,6 @@ export function Marker(props: MarkerProps): JSX.Element {
         position: 'absolute',
         transform: `translate(${props.left - width / 2}px, ${props.top - (height - 1)}px)`,
         filter: hover ? 'drop-shadow(0 0 4px rgba(0, 0, 0, .3))' : '',
-        pointerEvents: 'none',
         cursor: 'pointer',
         ...(props.style || {}),
       }}


### PR DESCRIPTION
pointer events none breaks custom markers by not having a cursor-pointer;, it also prevents the user from changing the map cursor to lets say cursor: grab;