### PR TITLE
Add back props to MultiLineString. closes #174

### DIFF
--- a/src/overlays/GeoJson.tsx
+++ b/src/overlays/GeoJson.tsx
@@ -78,7 +78,7 @@ export function MultiLineString(props: GeometryProps): JSX.Element {
   return (
     <>
       {props.coordinates.map((line, i) => (
-        <LineString coordinates={line} key={i} />
+        <LineString {...props} coordinates={line} key={i} />
       ))}
     </>
   )


### PR DESCRIPTION
as [djeka07](https://github.com/djeka07) explained on the issue #174, adding a geojson layer to the map that contains `geometry.type = MultiLineString` was causing an error: 
> TypeError: latLngToPixel is not a function

In GeoJson, MultiLineString function was maping coordinates to render LineString for each of them but the props were missing. I just readded them.

☑ tested on my [velotraces](https://github.com/aloxe/velotraces) project thanks to `patch-package`