### PR TITLE
Allow image option for PointComponent - Closes #209

### DIFF
--- a/src/overlays/GeoJson.tsx
+++ b/src/overlays/GeoJson.tsx
@@ -49,6 +49,10 @@ export function PointComponent(props: GeometryProps): JSX.Element {
   const { latLngToPixel } = props
   const [y, x] = props.coordinates as [number, number]
   const [cx, cy] = latLngToPixel([x, y])
+  if (props.svgAttributes?.path) {
+    const path = `M${cx},${cy}c${props.svgAttributes.path.split(/[c|C|L|l|v|V|h|H](.*)/s)[1]}`
+    return <path d={path} {...(props.svgAttributes as SVGProps<SVGCircleElement>)} />
+  }
   return <circle cx={cx} cy={cy} {...(props.svgAttributes as SVGProps<SVGCircleElement>)} />
 }
 


### PR DESCRIPTION
The current Point feature of the Geojson component can only be changed by changing the value of its radius.
```
 styleCallback={(feature) => {
          if (feature.geometry.type === "Point") {
            return {
              fill: "lightcoral",
              stroke: "darkred",
              strokeWidth: "2",
              r: "10",
            };
  }}
```
<img width="320" alt="Screenshot 2024-06-07 at 9 35 50" src="https://github.com/mariusandra/pigeon-maps/assets/6506888/bb9f730d-9b3d-45dd-9316-dca818649582">

The present change adds the possibility to add an svg path to the styleCallback that will be shown in place of the circle.
```
 styleCallback={(feature) => {
          if (feature.geometry.type === "Point") {
            return {
              fill: "lightcoral",
              stroke: "darkred",
              strokeWidth: "2",
              r: "10",
              path: "m 105.18118,144.78341 c 13.88218,-54.900853 47.12626,-20.15307 62.51039,-48.510217 11.48025,-21.161195 -7.88701,-40.52815 -23.30348,-40.545845 -12.98949,-0.01491 -23.75998,5.030014 -31.12524,15.691032 -9.61521,13.917797 -19.289599,24.284596 -8.08167,73.36503 m 32.30707,-76.511091 17.61856,12.899471 -17.30385,13.528373 z"
            };
  }}
```
<img width="285" alt="Screenshot 2024-06-07 at 9 35 35" src="https://github.com/mariusandra/pigeon-maps/assets/6506888/72dad5a2-2654-44cc-ba59-8cf9ebc44c0e">

To be able to display correctly, the path must be passed as a string and all coordinates must be relative. ( it is possible to [convert a path to relative here](https://codepen.io/leaverou/pen/RmwzKv) ). 
Also note that the first point of the path will be the one placed on the feature Point coordinates. Make sure the first point of the path is the base point of your pin.
Of course, it is also possible to use a nicer svg path than the one in the example.

