### PR TITLE
fix: Allow `children` to accept `ReactNode`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export interface MapProps {
 
   provider?: (x: number, y: number, z: number, dpr?: number) => string
   dprs?: number[]
-  children?: React.ReactElement
+  children?: React.ReactNode
 
   animate?: boolean
   animateMaxScreens?: number


### PR DESCRIPTION
Fixes error when using multiple children:

```
error TS2746: This JSX tag's 'children' prop expects a single child of type 'ReactElement<any, string | JSXElementConstructor<any>> | undefined', but multiple children were provided.
```