### PR TITLE
SSR: tolerate floating point imprecision 

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,8 @@
     }
   },
   "lint-staged": {
-    "*.{js,css,scss}": "prettier --write"
+    "*.{js,css,scss}": "prettier --write",
+    "src/**/*.tsx": "prettier --write",
+    "demo/**/*.tsx": "prettier --write"
   }
 }

--- a/src/map/Map.tsx
+++ b/src/map/Map.tsx
@@ -1047,10 +1047,18 @@ export class Map extends Component<MapProps, MapReactState> {
     const tileX = lng2tile(latLng[1], zoom)
     const tileY = lat2tile(latLng[0], zoom)
 
-    return [
-      (tileX - tileCenterX) * 256.0 + width / 2 + (pixelDelta ? pixelDelta[0] : 0),
-      (tileY - tileCenterY) * 256.0 + height / 2 + (pixelDelta ? pixelDelta[1] : 0),
-    ] as Point
+    const pixelX = (tileX - tileCenterX) * 256.0 + width / 2 + (pixelDelta ? pixelDelta[0] : 0)
+    const pixelY = (tileY - tileCenterY) * 256.0 + height / 2 + (pixelDelta ? pixelDelta[1] : 0)
+
+    // If SSR is used, this enclosing function must always return the same result for the same input.
+    // When the values are computed with e.g. Math.cos (Math.log, ...), the exact implementatiom is platform
+    // dependent and results can slightly vary.
+    // See https://stackoverflow.com/questions/26570626/math-log2-precision-has-changed-in-chrome
+    const roundMathImprecision = (pixel: number) => {
+      return Math.round(pixel * 1000) / 1000
+    }
+
+    return [roundMathImprecision(pixelX), roundMathImprecision(pixelY)]
   }
 
   calculateZoomCenter = (center: Point, coords: Point, oldZoom: number, newZoom: number): Point => {

--- a/src/overlays/Marker.tsx
+++ b/src/overlays/Marker.tsx
@@ -1,5 +1,11 @@
 import React, { useState } from 'react'
-import { PigeonProps } from '../types'
+import { PigeonProps, Point } from '../types'
+
+type CallbackArgs = {
+  event: React.MouseEvent
+  anchor: Point
+  payload: any
+}
 
 interface MarkerProps extends PigeonProps {
   color?: string
@@ -16,10 +22,10 @@ interface MarkerProps extends PigeonProps {
   children?: JSX.Element
 
   // callbacks
-  onClick?: ({ event: HTMLMouseEvent, anchor: Point, payload: any }) => void
-  onContextMenu?: ({ event: HTMLMouseEvent, anchor: Point, payload: any }) => void
-  onMouseOver?: ({ event: HTMLMouseEvent, anchor: Point, payload: any }) => void
-  onMouseOut?: ({ event: HTMLMouseEvent, anchor: Point, payload: any }) => void
+  onClick?: (arg: CallbackArgs) => void
+  onContextMenu?: (arg: CallbackArgs) => void
+  onMouseOver?: (arg: CallbackArgs) => void
+  onMouseOut?: (arg: CallbackArgs) => void
 }
 
 export function Marker(props: MarkerProps): JSX.Element {

--- a/src/overlays/Marker.tsx
+++ b/src/overlays/Marker.tsx
@@ -60,6 +60,8 @@ export function Marker<P = any>(props: MarkerProps<P>): JSX.Element {
         filter: hover ? 'drop-shadow(0 0 4px rgba(0, 0, 0, .3))' : '',
         pointerEvents: 'none',
         cursor: 'pointer',
+        width: width,
+        height: height,
         ...(props.style || {}),
       }}
       className={props.className ? `${props.className} pigeon-click-block` : 'pigeon-click-block'}

--- a/src/overlays/Marker.tsx
+++ b/src/overlays/Marker.tsx
@@ -1,15 +1,15 @@
 import React, { useState } from 'react'
 import { PigeonProps, Point } from '../types'
 
-type CallbackArgs = {
+type CallbackArgs<P> = {
   event: React.MouseEvent
   anchor: Point
-  payload: any
+  payload: P
 }
 
-interface MarkerProps extends PigeonProps {
+interface MarkerProps<P> extends PigeonProps {
   color?: string
-  payload?: any
+  payload?: P
 
   width?: number
   height?: number
@@ -22,13 +22,13 @@ interface MarkerProps extends PigeonProps {
   children?: JSX.Element
 
   // callbacks
-  onClick?: (arg: CallbackArgs) => void
-  onContextMenu?: (arg: CallbackArgs) => void
-  onMouseOver?: (arg: CallbackArgs) => void
-  onMouseOut?: (arg: CallbackArgs) => void
+  onClick?: (arg: CallbackArgs<P>) => void
+  onContextMenu?: (arg: CallbackArgs<P>) => void
+  onMouseOver?: (arg: CallbackArgs<P>) => void
+  onMouseOut?: (arg: CallbackArgs<P>) => void
 }
 
-export function Marker(props: MarkerProps): JSX.Element {
+export function Marker<P = any>(props: MarkerProps<P>): JSX.Element {
   const width =
     typeof props.width !== 'undefined'
       ? props.width


### PR DESCRIPTION
I encountered a weird bug during SSR hydration on the client. I discovered the cause to be `Math.cos` within `lat2tile` not yielding the same results on the server and in my browser, a difference not bigger than floating point imprecision.

It appears the issue is related to the problem described here: https://stackoverflow.com/questions/26570626/math-log2-precision-has-changed-in-chrome

Without these changes, the following mismatched diff causes the hydration error. 

```diff
+ position: "absolute"
- position: "absolute"
+ transform: "translate(6.019125609257912px, -138.1003211141433px)"
- transform: "translate(6.01913px, -138.1px)"
+ filter: ""
+ pointerEvents: "none"
+ cursor: "pointer"
- cursor: "pointer"
+ color: "black"
- color: "black"
+ transition: "color 0.2s linear"
- pointer-events: "none"
- transition-duration: "0.2s"
- transition-timing-function: "linear"
- transition-delay: "0s"
- transition-property: "color"
```

Note how the diff indicates that the `transition` property also indicates a problem (explicit vs. compact definition), but NextJS is actually able to understand that there is no issue in this case; the problem is solely caused by the arguably different `transform` values. This is why I believe this might be relevant for #168.

I also did some dogfood while I was on it, let me know what you think! And thank you for this awesome library 🚀 

**Node version:** 20.18.1
**React version:** 19.0.0
**NextJS version:** 15.1.6
**Client browser:** Chrome 132